### PR TITLE
Change Zendesk case and URL

### DIFF
--- a/_platforms/zendesk.md
+++ b/_platforms/zendesk.md
@@ -1,14 +1,14 @@
 ---
 layout: details
 filename: zendesk
-name: ZenDesk
+name: Zendesk
 image: /tech-radar/assets/images/platforms/zendesk.png 
 category: Platforms
 ring: Adopt
 ---
 
 # What is it ?
-ZenDesk is a SaaS platform dedicated to Customer Service
+Zendesk is a SaaS platform dedicated to Customer Service
 
 # Resources
-- [Homepage](https://www.zendesk.co.uk/)
+- [Homepage](https://www.zendesk.com/)


### PR DESCRIPTION
The official case for this company name is Zendesk, and they are an
American company. Their main site is zendesk.com, although there is a
geo-based redirection to zendesk.co.uk if the user is from the U.K.

This corrects the case from ZenDesk to Zendesk, and changes the URL to
point to their main site .com, instead of the U.K. version.